### PR TITLE
Update GitHub workflow branch and allow manual runs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,9 @@
 name: Build Docker image
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- trigger workflow on `master` instead of `main`
- add `workflow_dispatch` so it can be started manually

## Testing
- `poetry install`
- `poetry run course-management/manage.py migrate --settings=course.settings_test --noinput`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68487e33efb4832bbe70938cf2ce70c2