### PR TITLE
Copy README before Poetry install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.10-slim
 ENV PYTHONUNBUFFERED=1
 WORKDIR /app
-COPY pyproject.toml poetry.lock ./
+COPY pyproject.toml poetry.lock README.md ./
 RUN pip install --no-cache-dir poetry \
     && poetry config virtualenvs.create false \
-    && poetry install --no-dev --no-interaction --no-ansi
+    && poetry install --without dev --no-root --no-interaction --no-ansi
 COPY . .
 CMD ["python", "course-management/manage.py", "runserver", "0.0.0.0:8000"]


### PR DESCRIPTION
## Summary
- ensure Poetry sees README when installing
- skip installing local package during Docker build

## Testing
- `poetry install --no-interaction`
- `poetry run course-management/manage.py migrate --settings=course.settings_test --noinput`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68487f0184f4832ba5b1284ed70bb30b